### PR TITLE
Update azure-ai-agents version in requirements.txt

### DIFF
--- a/mcp_local_server_agent/agent/requirements.txt
+++ b/mcp_local_server_agent/agent/requirements.txt
@@ -1,4 +1,4 @@
 azure-ai-projects
-azure-ai-agents>=1_1.2.0b2
+azure-ai-agents>=1.2.0b2
 azure-identity
 python-dotenv>=1.0


### PR DESCRIPTION
Fixed azure-ai-agents package version

context:

requirements.txt has incorrect package version reference. 1_1.2.0.0b2 does not exist and leads to installation errors. https://pypi.org/project/azure-ai-agents/#history

error: "ERROR: Invalid requirement: 'azure-ai-agents>=1_1.2.0b2': Expected end or semicolon (after version specifier)
    azure-ai-agents>=1_1.2.0b2
                   ~~~^ (from line 2 of C:\Users\costaga\OneDrive - Microsoft\Documents\CSSwork\Repros\SemanticKernel\SK+MCP\azure-ai-agent-demos\mcp_local_server_agent\agent\requirements.txt)"