### PR TITLE
Add L200 tools training suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Every demo follows a consistent pattern:
 - `requirements.txt` — Python dependencies
 - `README.md` — Setup and walkthrough
 
+## Training labs
+
+The [`training/l200-tools/`](training/l200-tools/) suite accompanies the L200 Foundry tools training
+module for support engineers. Unlike the standalone demos, these labs form one sequence and share a
+single Python environment:
+
+1. Toolbox versioning
+2. Azure AI Search grounding
+3. Foundry IQ knowledge base
+
+The training README starts with Python, Git, Azure CLI, virtual-environment, dependency, and
+configuration setup for learners who have not used Python before.
+
 ## Quick Start
 
 ```bash

--- a/docs/architecture/decisions/005-connected-training-suites.md
+++ b/docs/architecture/decisions/005-connected-training-suites.md
@@ -1,0 +1,51 @@
+# ADR-005: Connected Training Suites
+
+## Status
+
+Accepted
+
+## Context
+
+The repository's standalone demos are independent examples built around `create_agent.py` and
+`ask_agent.py`. The L200 Foundry tools module is different: it teaches a staged build, break,
+diagnose, and fix workflow across three labs. Lab 3 intentionally reuses the Azure AI Search index
+from Lab 2.
+
+Forcing these labs into the standalone demo shape would either duplicate resources and setup or hide
+the sequence that the training is designed to teach.
+
+## Decision
+
+Connected learning content lives under `training/<suite-name>/`.
+
+A training suite:
+
+- may use multiple numbered scripts instead of the two-script demo pattern;
+- may share one virtual environment, dependency file, and `.env` file;
+- may carry state from one lab to the next when the dependency is explicit;
+- must provide a top-level clean-workstation setup guide;
+- must pin the validated direct dependencies;
+- must provide a preflight setup check;
+- must provide a README for every lab;
+- must not change the architecture rules for standalone demos.
+
+The L200 tools suite lives at `training/l200-tools/`.
+
+## Consequences
+
+### Positive
+
+- New learners configure Python and Azure authentication once.
+- The code preserves the same sequence taught by the module.
+- Standalone demos remain simple and independently runnable.
+- Future contributors can distinguish training content from capability demos.
+
+### Negative
+
+- Training suites use a different directory convention from root demos.
+- Cross-lab dependencies require clearer cleanup guidance.
+- Shared dependency pins must be refreshed when the training module is revalidated.
+
+### Neutral
+
+- A training suite can later be split into standalone demos if independent examples are needed.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -10,6 +10,7 @@ Record significant architecture decisions here. Each ADR documents the context, 
 | 002 | [Runtime-Only Auth Injection for MCP](002-runtime-only-auth-injection.md) | Accepted |
 | 003 | [GA V2 SDK with Conversations and Responses API](003-v2-sdk-and-openai-responses-api.md) | Accepted |
 | 004 | [Flat Demo Directory Layout](004-flat-demo-directory-layout.md) | Accepted |
+| 005 | [Connected Training Suites](005-connected-training-suites.md) | Accepted |
 
 ## ADR Template
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -2,7 +2,10 @@
 
 ## Overview
 
-A collection of self-contained Python demos, each showcasing a distinct Azure AI Foundry Agent capability. Every demo follows a consistent two-script pattern with streaming console output and clear documentation. The v1 archive is preserved for reference; active development targets the GA v2 SDK.
+A collection of self-contained Python demos and explicitly scoped training suites for Azure AI
+Foundry Agents. Standalone demos follow a consistent two-script pattern. Training suites may use
+staged scripts and shared setup when the labs form one learning sequence. The v1 archive is
+preserved for reference; active development targets the GA v2 SDK.
 
 ## High-Level Architecture
 
@@ -38,6 +41,7 @@ A collection of self-contained Python demos, each showcasing a distinct Azure AI
 | `enterprise_github_agent/` | GitHub MCP + Code Interpreter, approval flow, project connection auth | Complete (42 tests) |
 | `mcp_mslearn_agent/` | Public MS Learn MCP server, auto-approved, no auth | Complete (41 tests) |
 | `mcp_local_server_agent/` | Custom Chinook SQLite MCP server + agent, approval flow, optional auth | Complete (84 tests) |
+| `training/l200-tools/` | Connected Toolbox, Azure AI Search, and Foundry IQ labs | Complete |
 | `archive/v1/` | Original v1 demos (deprecated SDK), preserved for reference | Archived |
 
 ## Technology Choices
@@ -52,16 +56,21 @@ A collection of self-contained Python demos, each showcasing a distinct Azure AI
 | Conversations | OpenAI Responses API via `project.get_openai_client()` | [ADR-003](decisions/003-v2-sdk-and-openai-responses-api.md) |
 | Demo structure | Two-script pattern (`create_agent.py` + `ask_agent.py`) | [ADR-001](decisions/001-two-script-demo-pattern.md) |
 | Directory layout | Flat per demo, `server/` exception for MCP servers | [ADR-004](decisions/004-flat-demo-directory-layout.md) |
+| Training layout | Shared setup with staged, connected lab directories | [ADR-005](decisions/005-connected-training-suites.md) |
 | Config | `python-dotenv` (`.env` files) | Vision lock |
 | MCP transport | Streamable HTTP (not stdio) | Vision lock |
 
 ## Architectural Invariants
 
-1. **Two-script pattern** — Every demo has `create_agent.py` + `ask_agent.py`
+1. **Two-script pattern** — Every standalone demo has `create_agent.py` + `ask_agent.py`
 2. **Credential isolation** — External credentials stored in Foundry project connections, never on agent definitions
 3. **Streaming with tool visibility** — All demos show streaming tokens with visible tool call indicators
 4. **Self-contained demos** — Each directory has everything needed to run independently
 5. **Flat file layout** — No nested subdirectories, except `server/` where a custom MCP server is required
+
+Training suites under `training/` are a documented exception. They may share one environment and
+use staged scripts or cross-lab dependencies. They must provide a top-level setup guide, pinned
+dependencies, sample configuration, a preflight check, and per-lab READMEs.
 
 ## Data Flow
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -27,3 +27,7 @@ Project-specific terms and their definitions.
 **Streamable HTTP** — The MCP transport protocol used for remote agent↔server connections. Runs over standard HTTP (not stdio).
 
 **Two-script pattern** — Architecture invariant: every demo has `create_agent.py` (provision once) + `ask_agent.py` (interactive REPL). See ADR-001.
+
+**Training suite** — A set of connected labs under `training/` that share workstation setup,
+dependencies, configuration, or state. Training suites are documented exceptions to the standalone
+demo invariants. See ADR-005.

--- a/docs/vision/VISION-LOCK.md
+++ b/docs/vision/VISION-LOCK.md
@@ -1,7 +1,7 @@
 # Azure AI Agent Demos — Vision Lock
 
-**Version**: v1.3
-**Last updated**: 2026-04-07
+**Version**: v1.4
+**Last updated**: 2026-07-23
 
 ## Problem Statement
 
@@ -13,10 +13,16 @@ Azure developers learning to build AI agents with Azure AI Foundry — specifica
 - Want hands-on examples of agent capabilities (MCP integrations, Code Interpreter, file search, grounding, and more)
 - Need practical patterns for streaming output, tool call visibility, and runtime auth
 - Are following an accompanying walkthrough video/content series
+- Are new Foundry support engineers completing a connected, instructor-led training module
 
 ## Core Concept
 
-A collection of **self-contained Python demos**, each showcasing a distinct Azure AI Foundry Agent capability or integration pattern. Demos span MCP server connections, Code Interpreter, file search, grounding, and other tool types. Every demo follows a consistent two-script pattern (`create_agent.py` + `ask_agent.py`) with streaming console output and clear documentation. The v1 archive is preserved for reference; active development targets the GA v2 SDK and new Foundry portal.
+A collection of **self-contained Python demos**, each showcasing a distinct Azure AI Foundry Agent
+capability or integration pattern, plus explicitly scoped **training suites** that support connected
+learning modules. Every standalone demo follows a consistent two-script pattern
+(`create_agent.py` + `ask_agent.py`). Training suites may use staged scripts, shared setup, and
+cross-lab dependencies when the learning sequence requires them. The v1 archive is preserved for
+reference; active development targets the GA v2 SDK and new Foundry portal.
 
 ## Explicit Non-Goals
 
@@ -28,7 +34,9 @@ A collection of **self-contained Python demos**, each showcasing a distinct Azur
 
 ## Product Constraints
 
-- Every demo must be runnable independently with its own README, requirements, and `.env.sample`
+- Every standalone demo must be runnable independently with its own README, requirements, and `.env.sample`
+- A training suite must have one top-level setup guide, pinned dependencies, sample configuration,
+  a preflight check, and a README for each lab
 - Auth credentials (where applicable) must never be persisted on agent definitions — runtime injection only
 - V1 code in `archive/v1/` must remain untouched (referenced by existing walkthrough content)
 - Demos require an Azure AI Foundry project with public network access enabled
@@ -85,6 +93,7 @@ See [ADR-003](../architecture/decisions/003-v2-sdk-and-openai-responses-api.md) 
 | V2 Enterprise GitHub agent (`enterprise_github_agent/`) | Validated against GA SDK, fixed auth and API patterns | Compiles, not live-tested |
 | V2 MS Learn agent (`mcp_mslearn_agent/`) | Complete v2 demo: public MCP server, auto-approved, 41 tests | Compiles, not live-tested |
 | V2 Local server agent (`mcp_local_server_agent/`) | Complete v2 demo: custom MCP server, approval flow, 84 tests | Compiles, not live-tested |
+| L200 tools training suite (`training/l200-tools/`) | Three connected support-engineer labs with shared workstation setup | Compiles; live lab behavior previously validated |
 | Documentation skeleton | Empty templates in `docs/` | Yes |
 | Enterprise agent plan (`.github/prompts/plan-enterpriseGitHubAgent.prompt.md`) | Detailed plan, partially diverges from actual code | Yes |
 
@@ -101,14 +110,18 @@ See [ADR-003](../architecture/decisions/003-v2-sdk-and-openai-responses-api.md) 
 | Each demo has complete README with prerequisites, setup, and walkthrough | Not started |
 | Each demo has `.env.sample` with all required variables | Not started |
 | Architecture docs reflect actual implementation | Not started |
+| L200 tools training suite provides a clean-machine setup path and three connected labs | Complete |
 
-## Architecture Invariants
+## Standalone Demo Architecture Invariants
 
 1. **Two-script pattern** — Every demo has `create_agent.py` (provision once) + `ask_agent.py` (interactive REPL). No exceptions.
 2. **Credential isolation** — Where external services require credentials, they are stored in Foundry project connections and referenced by name, never embedded in agent definitions.
 3. **Streaming with tool visibility** — All demos show streaming token output with visible tool call indicators.
 4. **Self-contained demos** — Each demo directory contains everything needed to run it independently.
 5. **Flat file layout** — Demo directories use flat structure (no nested `agent/` or `server/` subdirectories), except where a separate MCP server is required.
+
+These invariants apply to standalone demos. A suite under `training/` may use staged scripts, shared
+dependencies, and cross-lab state when those choices are part of the learning design. See ADR-005.
 
 ## Where We're Going
 
@@ -148,3 +161,4 @@ Priority-ordered phases:
 | v1.1 | 2026-04-07 | Broadened scope beyond MCP-only; updated SDK from beta to GA per human feedback |
 | v1.2 | 2026-04-07 | Added Phases 5-7: Fabric Data Agent, Multi-Tool Knowledge Worker, Browser Automation |
 | v1.3 | 2026-04-07 | Architecture Invariant #2 updated: "credential isolation" via project connections (not runtime header injection). Enterprise agent prototype validated. |
+| v1.4 | 2026-07-23 | Added connected training suites as an explicit repository content type and approved the L200 tools suite exception. |

--- a/roadmap/CURRENT-STATE.md
+++ b/roadmap/CURRENT-STATE.md
@@ -1,12 +1,12 @@
 # Azure AI Agent Demos — Current State
 
-**Phase Status**: Complete
+**Phase Status**: L200 tools training package complete
 
 ## What Exists
 
 - `.github/` — Copilot agents, prompts, hooks, and instructions for autonomous development
-- `docs/vision/VISION-LOCK.md` — Vision lock v1.3 — credential isolation pattern, GA SDK
-- `docs/architecture/decisions/` — 4 ADRs (two-script pattern, project connection auth, GA v2 SDK, flat layout)
+- `docs/vision/VISION-LOCK.md` — Vision lock v1.4 — standalone demos plus connected training suites
+- `docs/architecture/decisions/` — 5 ADRs, including the connected-training-suite exception
 - `.github/skills/azure-docs-research/` — Skill for grounding answers in official MS docs
 - `docs/` — Architecture overview, glossary, tech debt tracker, reference docs
 - `roadmap/phases/` — Phase 1 (complete), Phase 2 (complete), Phase 3 (complete), Phase 4 (complete)
@@ -14,12 +14,14 @@
 - `enterprise_github_agent/` — Complete v2 demo: validated GA SDK patterns, project connection auth, typed MCP approvals, 42 passing tests, **E2E: agent creation verified**
 - `mcp_mslearn_agent/` — Complete v2 demo: public MS Learn MCP server, no auth, auto-approved, 41 passing tests, **E2E: fully verified (create + conversation + streaming + MCP tool calls)**
 - `mcp_local_server_agent/` — Complete v2 demo: custom MCP server (Chinook SQLite), approval flow, optional project connection auth, 84 passing tests, **E2E: fully verified (server + ngrok + create + conversation + approval flow + MCP tool calls)**
+- `training/l200-tools/` — Three connected support-engineer labs with Windows-first workstation
+  setup, one pinned virtual environment, shared `.env`, and a preflight checker
 - `archive/v1/` — Complete, working v1 demos preserved for reference
 - `pyproject.toml` — pytest importlib mode for test isolation across demos
 
 ## Current Phase
 
-E2E Testing — **COMPLETE**
+L200 tools training package — **COMPLETE**
 
 ## E2E Test Results (April 2026)
 
@@ -51,7 +53,8 @@ E2E Testing — **COMPLETE**
 
 ## Next Action
 
-Vision expansion — all three v2 demos are complete and E2E verified. Consider Phase 5 (Fabric Data Agent) or other new demos.
+Publish the L200 tools suite with the training module, then continue with Phase 5 or another approved
+demo.
 
 ## Blocked / Unresolved
 
@@ -67,12 +70,18 @@ Vision expansion — all three v2 demos are complete and E2E verified. Consider 
 - **E2E testing complete** — 2/3 demos fully verified, 1/3 partially verified (needs manual connection setup)
 - **DB working dir gitignored** — Added `**/db/working/` to .gitignore
 - **Project docs tracked in git** — Removed docs/, roadmap/, AGENTS.md from .gitignore
+- **L200 tools training package complete** — Three connected labs share one pinned environment,
+  configuration file, and preflight checker
 - ADR-001: Two-script demo pattern (create + ask)
 - ADR-002: MCP credentials via Foundry project connections (NOT runtime header injection)
 - ADR-003: GA V2 SDK with both response-chaining and Conversations API patterns
 - ADR-004: Flat demo directory layout (server/ exception for MCP server demos)
+- ADR-005: Connected training suites live under `training/` and may share setup and state
 
 ## Files Modified This Session
 
 - `.gitignore` — Added `**/db/working/` to ignore MCP server working DB copies
 - `roadmap/CURRENT-STATE.md` — Updated with E2E test results
+- `training/l200-tools/` — Added the portable L200 tools training suite
+- `docs/vision/VISION-LOCK.md` — Approved v1.4 training-suite exception
+- `docs/architecture/decisions/005-connected-training-suites.md` — Recorded the training layout

--- a/training/l200-tools/.env.sample
+++ b/training/l200-tools/.env.sample
@@ -1,0 +1,23 @@
+# Shared by all three labs.
+# Foundry project endpoint:
+# https://<account>.services.ai.azure.com/api/projects/<project>
+PROJECT_ENDPOINT=
+
+# Choose a current deployment that supports the tools used by the lab.
+MODEL_DEPLOYMENT_NAME=
+
+# Required by Labs 2 and 3. Use the Foundry project connection name for Azure AI Search.
+SEARCH_CONNECTION_NAME=
+
+# Required by Lab 3.
+# Full ARM ID of the Foundry project:
+# /subscriptions/<subscription>/resourceGroups/<resource-group>/providers/
+# Microsoft.CognitiveServices/accounts/<account>/projects/<project>
+PROJECT_RESOURCE_ID=
+
+# Azure OpenAI endpoint of the Foundry resource that hosts the Lab 3 model.
+# https://<account>.openai.azure.com
+AOAI_ENDPOINT=
+
+# Optional. Set only when the underlying model name differs from the deployment name.
+MODEL_NAME=

--- a/training/l200-tools/README.md
+++ b/training/l200-tools/README.md
@@ -1,0 +1,192 @@
+# L200 Foundry tools training labs
+
+These labs accompany the L200 training module for Microsoft Foundry Agents support engineers.
+Complete the workstation setup once, then work through the labs in order:
+
+1. [Lab 1: Toolbox versioning](lab1-toolbox/)
+2. [Lab 2: Azure AI Search grounding](lab2-ai-search/)
+3. [Lab 3: Foundry IQ knowledge base](lab3-foundry-iq/)
+
+Lab 3 reuses the Azure AI Search index created in Lab 2.
+
+## What you need
+
+- A Windows, macOS, or Linux workstation.
+- Python 3.11 or 3.12.
+- Git.
+- Azure CLI.
+- Access to the Foundry and Azure resources listed in each lab.
+
+Visual Studio Code is optional. If you use it, install the Microsoft Python extension.
+
+## Step 1: Install the workstation tools
+
+### Windows
+
+1. Install [Git for Windows](https://git-scm.com/download/win).
+2. Install [Python 3.12](https://www.python.org/downloads/windows/). Select **Add python.exe to
+   PATH** during installation.
+3. Install the [Azure CLI for Windows](https://learn.microsoft.com/cli/azure/install-azure-cli-windows).
+4. Open a new PowerShell window and verify:
+
+   ```powershell
+   git --version
+   py -3.12 --version
+   az version
+   ```
+
+### macOS or Linux
+
+Install:
+
+- [Git](https://git-scm.com/downloads);
+- [Python 3.11 or 3.12](https://www.python.org/downloads/);
+- [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli).
+
+Verify:
+
+```bash
+git --version
+python3 --version
+az version
+```
+
+## Step 2: Download the lab files
+
+Clone the repository:
+
+```bash
+git clone https://github.com/jcentner/azure-ai-agent-demos.git
+cd azure-ai-agent-demos/training/l200-tools
+```
+
+If Git is unavailable, download the repository ZIP from GitHub, extract it, and open
+`training/l200-tools`.
+
+## Step 3: Create the shared Python environment
+
+Use one virtual environment for all three labs.
+
+### Windows PowerShell
+
+```powershell
+py -3.12 -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+If PowerShell blocks the activation script, allow it for the current window and retry:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+.\.venv\Scripts\Activate.ps1
+```
+
+### macOS or Linux
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+```
+
+The prompt normally shows `(.venv)` while the environment is active. Activate it again whenever you
+open a new terminal.
+
+## Step 4: Sign in to Azure
+
+```bash
+az login
+az account show
+```
+
+If the browser cannot open, use:
+
+```bash
+az login --use-device-code
+```
+
+Confirm that the active subscription contains the Foundry project used for the labs. Change it when
+needed:
+
+```bash
+az account set --subscription "<subscription-name-or-id>"
+```
+
+## Step 5: Configure the labs
+
+Create your local configuration file.
+
+### Windows PowerShell
+
+```powershell
+Copy-Item .env.sample .env
+notepad .env
+```
+
+### macOS or Linux
+
+```bash
+cp .env.sample .env
+```
+
+Fill in the values:
+
+| Variable | Labs | Where to find it |
+|---|---|---|
+| `PROJECT_ENDPOINT` | 1, 2, 3 | Foundry project **Overview** page. It ends with `/api/projects/<project>`. |
+| `MODEL_DEPLOYMENT_NAME` | 1, 2, 3 | Foundry **Models + endpoints**. Choose a current deployment that supports the lab's tools. |
+| `SEARCH_CONNECTION_NAME` | 2, 3 | Foundry project's connected resources. Use the Azure AI Search connection name. |
+| `PROJECT_RESOURCE_ID` | 3 | Azure portal JSON view for the Foundry project resource. |
+| `AOAI_ENDPOINT` | 3 | Azure portal endpoint for the Foundry resource, ending in `.openai.azure.com`. |
+| `MODEL_NAME` | 3 | Optional. Set only when the underlying model name differs from the deployment name. |
+
+Do not commit `.env`. It is excluded by the repository's `.gitignore`.
+
+## Step 6: Check the setup
+
+Run the check for the lab you are about to start:
+
+```bash
+python check_setup.py --lab 1
+```
+
+Use `--lab 2`, `--lab 3`, or `--lab all` as needed. Continue only after every check reports
+`[PASS]`.
+
+## Running the labs
+
+Keep the virtual environment active, then change to the lab directory:
+
+```bash
+cd lab1-toolbox
+```
+
+Follow that directory's README. Return to this directory before starting the next lab:
+
+```bash
+cd ..
+python check_setup.py --lab 2
+cd lab2-ai-search
+```
+
+Do not run the Lab 2 cleanup if you plan to continue directly to Lab 3.
+
+## Common setup problems
+
+| Symptom | Fix |
+|---|---|
+| `python` opens the Microsoft Store or is not recognized | On Windows, use `py -3.12` to create the environment, then use `python` after activation. |
+| `No virtual environment is active` | Run the activation command from Step 3. |
+| `ModuleNotFoundError` | Activate `.venv`, then run `python -m pip install -r requirements.txt`. |
+| `az` is not recognized | Install Azure CLI, close the terminal, and open a new one. |
+| Azure authentication fails | Run `az login`, confirm `az account show`, and verify the intended subscription. |
+| An environment value is missing | Edit `.env`, then rerun `check_setup.py`. |
+
+When you finish all labs:
+
+```bash
+deactivate
+```

--- a/training/l200-tools/check_setup.py
+++ b/training/l200-tools/check_setup.py
@@ -1,0 +1,164 @@
+"""Check the local workstation setup before running an L200 tools lab."""
+
+import argparse
+import shutil
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+ENV_FILE = ROOT / ".env"
+MINIMUM_PYTHON = (3, 11)
+
+PACKAGES = {
+    "azure-ai-projects": "2.3.0",
+    "azure-identity": "1.25.3",
+    "azure-search-documents": "12.0.0",
+    "python-dotenv": "1.2.2",
+    "requests": "2.34.2",
+}
+
+LAB_VARIABLES = {
+    "1": ("PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME"),
+    "2": ("PROJECT_ENDPOINT", "MODEL_DEPLOYMENT_NAME", "SEARCH_CONNECTION_NAME"),
+    "3": (
+        "PROJECT_ENDPOINT",
+        "MODEL_DEPLOYMENT_NAME",
+        "SEARCH_CONNECTION_NAME",
+        "PROJECT_RESOURCE_ID",
+        "AOAI_ENDPOINT",
+    ),
+}
+
+
+def _read_env() -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not ENV_FILE.exists():
+        return values
+
+    for raw_line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip("\"'")
+    return values
+
+
+def _pass(message: str) -> None:
+    print(f"[PASS] {message}")
+
+
+def _fail(message: str) -> None:
+    print(f"[FAIL] {message}")
+
+
+def check_python() -> bool:
+    current = sys.version_info[:2]
+    if current < MINIMUM_PYTHON:
+        _fail(
+            f"Python {MINIMUM_PYTHON[0]}.{MINIMUM_PYTHON[1]} or later is required; "
+            f"found {current[0]}.{current[1]}."
+        )
+        return False
+    _pass(f"Python {sys.version.split()[0]}")
+    return True
+
+
+def check_virtual_environment() -> bool:
+    if sys.prefix == sys.base_prefix:
+        _fail("No virtual environment is active. Activate .venv and run this check again.")
+        return False
+    _pass(f"Virtual environment: {sys.prefix}")
+    return True
+
+
+def check_packages() -> bool:
+    ok = True
+    for package, expected in PACKAGES.items():
+        try:
+            installed = metadata.version(package)
+        except metadata.PackageNotFoundError:
+            _fail(f"{package} is not installed.")
+            ok = False
+            continue
+
+        if installed != expected:
+            _fail(f"{package} {installed} is installed; expected {expected}.")
+            ok = False
+        else:
+            _pass(f"{package} {installed}")
+    return ok
+
+
+def check_azure_cli() -> bool:
+    executable = shutil.which("az")
+    if not executable:
+        _fail("Azure CLI was not found on PATH.")
+        return False
+
+    result = subprocess.run(
+        [executable, "account", "show", "--output", "none"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        _fail("Azure CLI is installed, but no active login was found. Run: az login")
+        return False
+
+    _pass("Azure CLI login")
+    return True
+
+
+def check_configuration(lab: str) -> bool:
+    if not ENV_FILE.exists():
+        _fail(f"{ENV_FILE} does not exist. Copy .env.sample to .env and fill in the values.")
+        return False
+
+    values = _read_env()
+    required = LAB_VARIABLES[lab] if lab != "all" else tuple(
+        dict.fromkeys(variable for variables in LAB_VARIABLES.values() for variable in variables)
+    )
+    missing = [variable for variable in required if not values.get(variable)]
+    if missing:
+        _fail(f"Missing values in .env: {', '.join(missing)}")
+        return False
+
+    endpoint = values.get("PROJECT_ENDPOINT", "")
+    if not endpoint.startswith("https://") or "/api/projects/" not in endpoint:
+        _fail("PROJECT_ENDPOINT does not match the Foundry project endpoint format.")
+        return False
+
+    _pass(f"Configuration for Lab {lab}" if lab != "all" else "Configuration for all labs")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--lab",
+        choices=("1", "2", "3", "all"),
+        default="all",
+        help="Check only the environment variables needed by one lab.",
+    )
+    args = parser.parse_args()
+
+    checks = [
+        check_python(),
+        check_virtual_environment(),
+        check_packages(),
+        check_azure_cli(),
+        check_configuration(args.lab),
+    ]
+    if all(checks):
+        print("\nSetup is ready.")
+        return 0
+
+    print("\nSetup is not ready. Fix the failed items and run this command again.")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/training/l200-tools/lab1-toolbox/00_reset.py
+++ b/training/l200-tools/lab1-toolbox/00_reset.py
@@ -1,0 +1,19 @@
+"""Phase 0 (optional) - Reset. Delete the lab toolbox so 01_build_v1 starts clean.
+
+Run this before re-running the lab. create_version on an existing toolbox appends a
+new version instead of starting over.
+"""
+
+from common import TOOLBOX_NAME, project
+
+
+def main():
+    try:
+        project.toolboxes.delete(TOOLBOX_NAME)
+        print(f"deleted toolbox {TOOLBOX_NAME}")
+    except Exception as exc:  # toolbox may not exist yet
+        print(f"nothing to delete ({str(exc)[:80]})")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab1-toolbox/01_build_v1.py
+++ b/training/l200-tools/lab1-toolbox/01_build_v1.py
@@ -1,0 +1,26 @@
+"""Phase 1 - Build the toolbox (v1 = Web Search).
+
+Creates the toolbox with a single tool. The first version of a new toolbox is
+automatically promoted to default_version, so the consumer endpoint serves it
+right away.
+"""
+
+from azure.ai.projects.models import WebSearchToolboxTool
+
+from common import TOOLBOX_NAME, project
+
+
+def main():
+    version = project.toolboxes.create_version(
+        name=TOOLBOX_NAME,
+        description="Lab 1 v1: web search only",
+        tools=[WebSearchToolboxTool(description="Search the public web for current information.")],
+    )
+    print(f"Created {version.name} version {version.version}: {[t.type for t in version.tools]}")
+
+    toolbox = project.toolboxes.get(TOOLBOX_NAME)
+    print(f"default_version = {toolbox.default_version}  (first version auto-promoted)")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab1-toolbox/02_use_v1.py
+++ b/training/l200-tools/lab1-toolbox/02_use_v1.py
@@ -1,0 +1,25 @@
+"""Phase 2 - Two agents share one toolbox.
+
+Both agents point at the same consumer endpoint. Neither declares any tool of its
+own; they discover Web Search from the toolbox. This is the toolbox value prop:
+configure tools once, reuse across agents.
+"""
+
+from common import consumer_endpoint, run_agent
+
+
+def main():
+    url = consumer_endpoint()
+
+    for label, prompt in [
+        ("news-agent", "Use web search: give one current headline about Azure, with the source URL."),
+        ("research-agent", "Use web search: what did Microsoft announce most recently about Foundry? Cite a URL."),
+    ]:
+        tools_seen, tool_calls, answer = run_agent(prompt, server_label=label, url=url)
+        print(f"\n[{label}] tools discovered: {tools_seen}")
+        print(f"[{label}] tool calls: {tool_calls}")
+        print(f"[{label}] {answer[:200]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab1-toolbox/03_build_v2.py
+++ b/training/l200-tools/lab1-toolbox/03_build_v2.py
@@ -1,0 +1,43 @@
+"""Phase 3 - Build v2 (Web Search + Code Interpreter) but do NOT promote it.
+
+Creating a new version does not change default_version. This sets up the break:
+the consumer endpoint still serves v1, so agents still see only Web Search, while
+the version-specific developer endpoint serves the full v2 tool set.
+
+Toolbox rule: at most ONE unnamed tool per toolbox. v1's Web Search was unnamed, so
+here Code Interpreter must be named or the create call fails with:
+    invalid_payload "Multiple tools without identifiers found".
+"""
+
+from azure.ai.projects.models import (
+    AutoCodeInterpreterToolParam,
+    CodeInterpreterToolboxTool,
+    WebSearchToolboxTool,
+)
+
+from common import TOOLBOX_NAME, developer_endpoint, project, tools_list
+
+
+def main():
+    version = project.toolboxes.create_version(
+        name=TOOLBOX_NAME,
+        description="Lab 1 v2: web search + code interpreter",
+        tools=[
+            WebSearchToolboxTool(description="Search the public web for current information."),
+            CodeInterpreterToolboxTool(
+                name="code_interpreter",
+                description="Run Python to do calculations and data work.",
+                container=AutoCodeInterpreterToolParam(),
+            ),
+        ],
+    )
+    print(f"Created version {version.version}: {[(t.type, getattr(t, 'name', None)) for t in version.tools]}")
+
+    toolbox = project.toolboxes.get(TOOLBOX_NAME)
+    print(f"default_version = {toolbox.default_version}  (still points at v1 - not promoted)")
+
+    print(f"developer (v{version.version}) tools/list: {tools_list(developer_endpoint(version.version))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab1-toolbox/04_diagnose.py
+++ b/training/l200-tools/lab1-toolbox/04_diagnose.py
@@ -1,0 +1,41 @@
+"""Phase 4 - Diagnose the break.
+
+Symptom: an agent that could search the web suddenly cannot do compute, even
+though you "added" Code Interpreter. Work from ground truth, not the model's words.
+
+Three checks, in order:
+  1. Consumer endpoint tools/list  -> what agents actually get right now.
+  2. toolboxes.get().default_version -> which version the consumer serves.
+  3. list_versions()               -> confirm the tool you expected lives in a
+                                       version that is NOT the default.
+
+Portal trap: the Foundry Toolkit UI shows the LATEST version, so it looks like
+Code Interpreter is there. The consumer endpoint serves the DEFAULT version, which
+is a different thing. Version list and promotion are SDK/REST/azd only.
+"""
+
+from common import TOOLBOX_NAME, consumer_endpoint, project, run_agent, tools_list
+
+
+def main():
+    print("1) consumer tools/list:", tools_list(consumer_endpoint()))
+
+    toolbox = project.toolboxes.get(TOOLBOX_NAME)
+    print("2) default_version   :", toolbox.default_version)
+
+    print("3) all versions      :")
+    for version in project.toolboxes.list_versions(TOOLBOX_NAME):
+        print(f"     v{version.version}: {[t.type for t in version.tools]}")
+
+    tools_seen, tool_calls, answer = run_agent(
+        "Use the code interpreter tool to compute the 15th Fibonacci number. "
+        "If you cannot, say which tool is missing.",
+        server_label="compute-agent",
+        url=consumer_endpoint(),
+    )
+    print("\nagent tools seen:", tools_seen, "| tool calls:", tool_calls)
+    print("agent said:", answer[:200])
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab1-toolbox/05_fix.py
+++ b/training/l200-tools/lab1-toolbox/05_fix.py
@@ -1,0 +1,46 @@
+"""Phase 5 - Fix by promoting v2 to default.
+
+One call moves default_version to v2. The consumer endpoint picks it up
+immediately - no agent code change, no redeploy.
+
+Success criterion for this lab: after promotion, code_interpreter is now part of
+the agent's toolset (visible in the agent's tool list and in the consumer
+tools/list). That proves the version change reached the agent.
+
+Runtime cache gotcha: the endpoint updates instantly, but the agent runtime caches
+an MCP server's tool list keyed by (server_label + server_url) with a long TTL. An
+agent that already cached the old list under a server_label keeps serving the old
+tool set. A fresh server_label (a new agent/session) sees the new tool right away.
+Below, "compute-agent-v2" is a fresh label, so it sees Code Interpreter at once.
+
+Preview limitation (troubleshooting sidebar): invoking Code Interpreter THROUGH a
+toolbox currently returns a ServerError in preview. Native Code Interpreter
+(attached directly to an agent, not via a toolbox) is unaffected. This lab's goal
+is the version contract - that the promoted tool becomes available - not code
+execution, so we assert the tool is present rather than run it.
+"""
+
+from common import TOOLBOX_NAME, consumer_endpoint, project, run_agent, tools_list
+
+
+def main():
+    toolbox = project.toolboxes.update(TOOLBOX_NAME, default_version="2")
+    print("promoted. default_version =", toolbox.default_version)
+
+    served = tools_list(consumer_endpoint())
+    print("consumer tools/list (endpoint, instant):", served)
+    assert "code_interpreter" in served, "consumer endpoint should now serve code_interpreter"
+
+    tools_seen, tool_calls, answer = run_agent(
+        "List the tools you can call, then use web search for one current Azure headline with a URL.",
+        server_label="compute-agent-v2",  # fresh label -> no stale cache
+        url=consumer_endpoint(),
+    )
+    print("\nfresh agent tools seen:", tools_seen, "| tool calls:", tool_calls)
+    print("fresh agent said:", answer[:200])
+    assert "code_interpreter" in tools_seen, "agent should now see code_interpreter in its toolset"
+    print("\nPASS: code_interpreter is now available to the agent after promotion.")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab1-toolbox/README.md
+++ b/training/l200-tools/lab1-toolbox/README.md
@@ -1,0 +1,64 @@
+# Lab 1: Toolbox versioning
+
+This lab demonstrates the Toolbox build, break, diagnose, and fix workflow. The consumer endpoint
+serves the default Toolbox version. Creating a later version does not change the default until that
+version is promoted.
+
+Follow the L200 module for the teaching steps and screenshots. This README is the operational
+companion for running the code.
+
+## Before you begin
+
+1. Complete the [shared workstation setup](../README.md).
+2. Activate `training/l200-tools/.venv`.
+3. Fill in `PROJECT_ENDPOINT` and `MODEL_DEPLOYMENT_NAME` in `training/l200-tools/.env`.
+4. Choose a current model deployment that supports MCP, Web Search, and Code Interpreter.
+5. From `training/l200-tools`, run:
+
+   ```bash
+   python check_setup.py --lab 1
+   cd lab1-toolbox
+   ```
+
+## Run order
+
+| Script | Purpose |
+|---|---|
+| `00_reset.py` | Delete the lab Toolbox so the exercise starts clean. |
+| `01_build_v1.py` | Create version 1 with Web Search. The first version becomes the default. |
+| `02_use_v1.py` | Show two agents discovering tools from the shared consumer endpoint. |
+| `03_build_v2.py` | Create version 2 with Web Search and Code Interpreter without promoting it. |
+| `04_diagnose.py` | Compare the consumer endpoint, default version, and available versions. |
+| `05_fix.py` | Promote version 2 and verify Code Interpreter becomes available. |
+
+Run each command separately so you can inspect the portal and module screenshots between steps:
+
+```bash
+python 00_reset.py
+python 01_build_v1.py
+python 02_use_v1.py
+python 03_build_v2.py
+python 04_diagnose.py
+python 05_fix.py
+```
+
+The lab succeeds when `05_fix.py` prints:
+
+```text
+PASS: code_interpreter is now available to the agent after promotion.
+```
+
+## Cleanup
+
+```bash
+python 00_reset.py
+```
+
+## Common execution problems
+
+| Symptom | Check |
+|---|---|
+| A required environment value is missing | Edit `../.env`, then rerun `python ../check_setup.py --lab 1`. |
+| Azure authentication fails | Run `az login` and confirm the intended subscription with `az account show`. |
+| Code Interpreter is absent after creating version 2 | Continue to `04_diagnose.py`; version 2 is intentionally not the default yet. |
+| The endpoint is updated but an existing agent still sees the old list | Use the fresh server label in `05_fix.py`; the runtime can cache MCP tool discovery. |

--- a/training/l200-tools/lab1-toolbox/common.py
+++ b/training/l200-tools/lab1-toolbox/common.py
@@ -1,0 +1,105 @@
+"""Shared helpers for Lab 1 (Foundry Toolbox versioning).
+
+Every script imports from here so the setup lives in one place.
+
+Auth model for this lab:
+- We mint a fresh Entra token at call time (scope https://ai.azure.com/.default)
+  and hand it to the toolbox MCP endpoint. The raw azure-ai-projects SDK does NOT
+  auto-inject managed identity for a first-party toolbox, so the token is explicit.
+- Minting per call means the token never goes stale mid-lab.
+"""
+
+import json
+import os
+import urllib.request
+from pathlib import Path
+
+from azure.ai.projects import AIProjectClient
+from azure.identity import DefaultAzureCredential
+from dotenv import load_dotenv
+
+TOOLBOX_NAME = "lab1tools"
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+MODEL = os.environ.get("MODEL_DEPLOYMENT_NAME")
+PROJECT_ENDPOINT = os.environ.get("PROJECT_ENDPOINT")
+
+
+def _required(value: str | None, variable: str) -> str:
+    if not value:
+        raise RuntimeError(f"Set {variable} in training/l200-tools/.env.")
+    return value
+
+_credential = DefaultAzureCredential()
+project = AIProjectClient(
+    endpoint=_required(PROJECT_ENDPOINT, "PROJECT_ENDPOINT"),
+    credential=_credential,
+)
+
+
+def token() -> str:
+    """Fresh Entra token for the toolbox MCP endpoint."""
+    return _credential.get_token("https://ai.azure.com/.default").token
+
+
+def consumer_endpoint() -> str:
+    """Always serves the toolbox's default_version. This is what agents use."""
+    return f"{PROJECT_ENDPOINT}/toolboxes/{TOOLBOX_NAME}/mcp?api-version=v1"
+
+
+def developer_endpoint(version: str) -> str:
+    """Serves one specific version. Use to test a version before promoting it."""
+    return f"{PROJECT_ENDPOINT}/toolboxes/{TOOLBOX_NAME}/versions/{version}/mcp?api-version=v1"
+
+
+def tools_list(url: str) -> list:
+    """Raw MCP tools/list against a toolbox endpoint. Shows exactly what the
+    endpoint serves right now - the deterministic ground truth for diagnosis."""
+    body = json.dumps({"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}}).encode()
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {token()}",
+            "Content-Type": "application/json",
+            "Accept": "application/json, text/event-stream",
+        },
+    )
+    with urllib.request.urlopen(request) as response:
+        payload = json.loads(response.read().decode())
+    return [t["name"] for t in payload["result"]["tools"]]
+
+
+def toolbox_tool(server_label: str, url: str) -> dict:
+    """The toolbox as one MCP tool on an agent call."""
+    return {
+        "type": "mcp",
+        "server_label": server_label,
+        "server_url": url,
+        "require_approval": "never",
+        "authorization": token(),
+    }
+
+
+def run_agent(instructions_input: str, server_label: str, url: str):
+    """One agent turn against the toolbox. Returns (tools_seen, answer)."""
+    if not MODEL:
+        raise RuntimeError(
+            "Set MODEL_DEPLOYMENT_NAME to a model deployment that supports MCP, "
+            "Web Search, and Code Interpreter."
+        )
+    client = project.get_openai_client()
+    response = client.responses.create(
+        model=MODEL,
+        input=instructions_input,
+        tools=[toolbox_tool(server_label, url)],
+    )
+    tools_seen, tool_calls = [], []
+    for item in response.output:
+        kind = getattr(item, "type", None)
+        if kind == "mcp_list_tools":
+            tools_seen = [t.name for t in item.tools]
+        elif kind == "mcp_call":
+            tool_calls.append(getattr(item, "name", ""))
+    return tools_seen, tool_calls, (response.output_text or "")

--- a/training/l200-tools/lab2-ai-search/00_reset.py
+++ b/training/l200-tools/lab2-ai-search/00_reset.py
@@ -1,0 +1,23 @@
+"""Phase 0 (optional) - Reset. Delete the index and the lab agent for a clean re-run."""
+
+import common
+from azure.search.documents.indexes import SearchIndexClient
+
+
+def main():
+    try:
+        SearchIndexClient(endpoint=common.SEARCH_ENDPOINT, credential=common._credential).delete_index(
+            common.INDEX_NAME
+        )
+        print(f"deleted index {common.INDEX_NAME}")
+    except Exception as exc:
+        print(f"index not deleted ({str(exc)[:80]})")
+    try:
+        common.project.agents.delete("hr-benefits-agent")
+        print("deleted agent hr-benefits-agent")
+    except Exception as exc:
+        print(f"agent not deleted ({str(exc)[:80]})")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab2-ai-search/01_create_index.py
+++ b/training/l200-tools/lab2-ai-search/01_create_index.py
@@ -1,0 +1,30 @@
+"""Phase 1 - Create the index and load the document set.
+
+Creates the contoso-benefits index (keyword + semantic, no vectors) on the project's AI Search
+service and uploads the markdown files in data/. Re-runnable: create_or_update + upsert.
+"""
+
+import time
+
+import common
+
+
+def main():
+    common.create_index()
+    print(f"index ready: {common.INDEX_NAME} on {common.SEARCH_ENDPOINT}")
+    n = common.upload_docs()
+    print(f"uploaded {n} documents")
+    time.sleep(3)  # let the index catch up before a sanity query
+    hits = list(
+        common._search_client().search(
+            search_text="PTO days for new employees",
+            top=1,
+            query_type="semantic",
+            semantic_configuration_name=common.SEMANTIC_CONFIG,
+        )
+    )
+    print("sanity search top hit:", hits[0]["id"] if hits else None)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab2-ai-search/02_query.py
+++ b/training/l200-tools/lab2-ai-search/02_query.py
@@ -1,0 +1,46 @@
+"""Phase 3 - Build the grounded agent and verify cited answers.
+
+(Phase 2 is RBAC - see README. The agent reaches AI Search as the PROJECT managed identity, which
+needs Search Index Data Reader + Search Service Contributor on the search service.)
+
+Builds one agent with the AzureAISearch tool bound to the index, asks grounded questions, and checks
+that the tool was called and the answer carries citations. A final off-topic question confirms the
+agent stays grounded (answers "I don't know" instead of using model memory).
+"""
+
+import common
+from common import AzureAISearchQueryType
+
+
+def main():
+    agent = common.build_agent("hr-benefits-agent", AzureAISearchQueryType.SEMANTIC)
+    print(f"agent: {agent.name} v{agent.version} (query_type=semantic, top_k=5)\n")
+
+    grounded = [
+        "How many PTO days do new employees get?",
+        "What is Contoso's 401k match?",
+        "How much is the home office stipend?",
+    ]
+    for q in grounded:
+        answer, tool_used, annotations = common.run_agent(agent, q)
+        print(f"Q: {q}")
+        print(f"   tool_used={tool_used} citations={annotations}")
+        print(f"   A: {answer}\n")
+        assert tool_used, "expected the AI Search tool to be called"
+        assert annotations > 0, "expected at least one citation"
+
+    # Negative case: not in the docs -> the agent should decline, not answer from memory.
+    off_topic = "What is the capital of France?"
+    answer, tool_used, annotations = common.run_agent(agent, off_topic)
+    print(f"Q (off-topic): {off_topic}")
+    print(f"   tool_used={tool_used} citations={annotations}")
+    print(f"   A: {answer}\n")
+    declined = "don't know" in answer.lower() or "do not know" in answer.lower()
+    assert declined, f"expected a decline for the off-topic question, got: {answer!r}"
+    assert "paris" not in answer.lower(), f"agent answered from memory instead of declining: {answer!r}"
+
+    print("PASS: grounded answers are cited; off-topic question is declined.")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab2-ai-search/README.md
+++ b/training/l200-tools/lab2-ai-search/README.md
@@ -1,0 +1,71 @@
+# Lab 2: Azure AI Search grounding
+
+This lab attaches one Azure AI Search index directly to one agent. The agent must use the Search
+tool, cite indexed content, and decline a question that the index cannot answer.
+
+Follow the L200 module for the teaching steps and screenshots. This README is the operational
+companion for running the code.
+
+## Before you begin
+
+1. Complete the [shared workstation setup](../README.md).
+2. Activate `training/l200-tools/.venv`.
+3. Fill in `PROJECT_ENDPOINT`, `MODEL_DEPLOYMENT_NAME`, and `SEARCH_CONNECTION_NAME` in
+   `training/l200-tools/.env`.
+4. Choose a current model deployment that supports Azure AI Search.
+5. Confirm the Search project connection uses Microsoft Entra authentication.
+6. From `training/l200-tools`, run:
+
+   ```bash
+   python check_setup.py --lab 2
+   cd lab2-ai-search
+   ```
+
+## Required roles
+
+Assign roles on the Azure AI Search service:
+
+| Identity | Roles |
+|---|---|
+| Your user account | `Search Service Contributor` and `Search Index Data Contributor` |
+| Foundry project managed identity | `Search Index Data Contributor` and `Search Service Contributor` |
+
+The agent reaches Search as the **project** managed identity, not the parent Foundry account
+identity. Role assignments can take several minutes to propagate.
+
+## Run order
+
+| Script | Purpose |
+|---|---|
+| `00_reset.py` | Delete the lab index and agent for a clean rerun. |
+| `01_create_index.py` | Create `contoso-benefits` and upload the six documents in `data/`. |
+| `02_query.py` | Create the grounded agent and verify cited answers and an off-topic decline. |
+
+Run each command separately:
+
+```bash
+python 00_reset.py
+python 01_create_index.py
+python 02_query.py
+```
+
+The lab succeeds when `02_query.py` prints its final `PASS` result.
+
+## Cleanup
+
+If you are continuing to Lab 3, do not run cleanup. Lab 3 reuses the `contoso-benefits` index.
+
+Otherwise:
+
+```bash
+python 00_reset.py
+```
+
+## Common execution problems
+
+| Symptom | Check |
+|---|---|
+| `Access denied` or `tool_user_error` | Verify roles are assigned to the Foundry project managed identity and allow time for propagation. |
+| The index contains no documents | Confirm the six Markdown files exist in `data/` and rerun `01_create_index.py`. |
+| The agent returns an uncited answer | Confirm the Search tool is attached and the selected model supports Azure AI Search. |
+| The wrong Search service is used | Verify `SEARCH_CONNECTION_NAME` in `../.env`. |

--- a/training/l200-tools/lab2-ai-search/common.py
+++ b/training/l200-tools/lab2-ai-search/common.py
@@ -1,0 +1,161 @@
+"""Shared helpers for Lab 2 (Azure AI Search grounding).
+
+Every script imports from here so setup lives in one place.
+
+Grounding model for this lab:
+- We create a plain Azure AI Search index over a small document set and attach it to ONE agent as
+  the built-in AzureAISearch tool. The agent answers only from the index and cites its sources.
+- Auth to the search service uses the project's AI Search *connection* (Entra/AAD). The Foundry
+  service reaches Search under the project identity, so that identity needs the Search data-plane
+  roles (see README Phase 2).
+"""
+
+import glob
+import os
+import re
+from pathlib import Path
+
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import (
+    AISearchIndexResource,
+    AzureAISearchQueryType,
+    AzureAISearchTool,
+    AzureAISearchToolResource,
+    PromptAgentDefinition,
+)
+from azure.identity import DefaultAzureCredential
+from azure.search.documents import SearchClient
+from azure.search.documents.indexes import SearchIndexClient
+from azure.search.documents.indexes.models import (
+    SearchableField,
+    SearchField,
+    SearchFieldDataType,
+    SearchIndex,
+    SemanticConfiguration,
+    SemanticField,
+    SemanticPrioritizedFields,
+    SemanticSearch,
+    SimpleField,
+)
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+MODEL = os.environ.get("MODEL_DEPLOYMENT_NAME")
+INDEX_NAME = "contoso-benefits"
+SEARCH_CONNECTION_NAME = os.environ.get("SEARCH_CONNECTION_NAME")
+SEMANTIC_CONFIG = "default"
+DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
+
+PROJECT_ENDPOINT = os.environ.get("PROJECT_ENDPOINT")
+
+
+def _required(value: str | None, variable: str) -> str:
+    if not value:
+        raise RuntimeError(f"Set {variable} in training/l200-tools/.env.")
+    return value
+
+_credential = DefaultAzureCredential()
+project = AIProjectClient(
+    endpoint=_required(PROJECT_ENDPOINT, "PROJECT_ENDPOINT"),
+    credential=_credential,
+)
+
+_conn = project.connections.get(_required(SEARCH_CONNECTION_NAME, "SEARCH_CONNECTION_NAME"))
+SEARCH_ENDPOINT = _conn.target.rstrip("/")
+SEARCH_CONNECTION_ID = _conn.id
+
+
+def _index_client() -> SearchIndexClient:
+    return SearchIndexClient(endpoint=SEARCH_ENDPOINT, credential=_credential)
+
+
+def _search_client() -> SearchClient:
+    return SearchClient(endpoint=SEARCH_ENDPOINT, index_name=INDEX_NAME, credential=_credential)
+
+
+def create_index() -> None:
+    """Create the contoso-benefits index (keyword + semantic; no vectors for the first pass)."""
+    index = SearchIndex(
+        name=INDEX_NAME,
+        fields=[
+            SimpleField(name="id", type=SearchFieldDataType.String, key=True),
+            SearchableField(name="title", type=SearchFieldDataType.String),
+            SearchableField(name="content", type=SearchFieldDataType.String),
+            SimpleField(name="category", type=SearchFieldDataType.String, filterable=True),
+        ],
+        semantic_search=SemanticSearch(
+            configurations=[
+                SemanticConfiguration(
+                    name=SEMANTIC_CONFIG,
+                    prioritized_fields=SemanticPrioritizedFields(
+                        title_field=SemanticField(field_name="title"),
+                        content_fields=[SemanticField(field_name="content")],
+                    ),
+                )
+            ]
+        ),
+    )
+    _index_client().create_or_update_index(index)
+
+
+def upload_docs() -> int:
+    """Load every markdown file in data/ as one document. Returns the count uploaded."""
+    docs = []
+    for path in sorted(glob.glob(os.path.join(DATA_DIR, "*.md"))):
+        text = open(path, encoding="utf-8").read()
+        first_line = text.splitlines()[0]
+        title = re.sub(r"^#\s*", "", first_line).strip()
+        doc_id = os.path.splitext(os.path.basename(path))[0]
+        docs.append({"id": doc_id, "title": title, "content": text, "category": "benefits"})
+    _search_client().upload_documents(documents=docs)
+    return len(docs)
+
+
+def build_agent(agent_name: str, query_type: AzureAISearchQueryType) -> object:
+    """Create an agent version with the AzureAISearch tool bound to the index."""
+    if not MODEL:
+        raise RuntimeError(
+            "Set MODEL_DEPLOYMENT_NAME to a model deployment that supports Azure AI Search."
+        )
+    tool = AzureAISearchTool(
+        azure_ai_search=AzureAISearchToolResource(
+            indexes=[
+                AISearchIndexResource(
+                    project_connection_id=SEARCH_CONNECTION_ID,
+                    index_name=INDEX_NAME,
+                    query_type=query_type,
+                    top_k=5,
+                )
+            ]
+        )
+    )
+    instructions = (
+        "You are the Contoso HR assistant. Answer employee questions using ONLY the Azure AI Search "
+        "tool results. Cite the source document. If the answer is not in the results, say you don't "
+        "know."
+    )
+    return project.agents.create_version(
+        agent_name=agent_name,
+        definition=PromptAgentDefinition(model=MODEL, instructions=instructions, tools=[tool]),
+    )
+
+
+def run_agent(agent, question: str):
+    """One turn against the grounded agent. Returns (answer, tool_used, annotation_count)."""
+    oc = project.get_openai_client()
+    response = oc.responses.create(
+        input=question,
+        extra_body={
+            "agent_reference": {"type": "agent_reference", "name": agent.name, "version": agent.version}
+        },
+    )
+    tool_used = False
+    annotations = 0
+    for item in response.output:
+        if getattr(item, "type", None) in ("azure_ai_search_call", "file_search_call", "tool_call"):
+            tool_used = True
+        if getattr(item, "type", None) == "message":
+            for block in getattr(item, "content", []) or []:
+                annotations += len(getattr(block, "annotations", []) or [])
+    return (response.output_text or ""), tool_used, annotations

--- a/training/l200-tools/lab2-ai-search/data/expense-policy.md
+++ b/training/l200-tools/lab2-ai-search/data/expense-policy.md
@@ -1,0 +1,12 @@
+# Expense Reimbursement Policy
+
+Employees are reimbursed for reasonable, pre-approved business expenses. Submit expense reports
+through the Contoso Expenses portal within **30 days** of incurring the expense.
+
+- Meals during business travel are reimbursed up to **$75 per day**.
+- Standard airfare is economy class; business class requires VP approval for flights over eight
+  hours.
+- Ground transportation, lodging, and conference fees are reimbursed at actual cost with receipts.
+
+Receipts are required for any expense over **$25**. Reimbursements are paid within two pay cycles of
+approval.

--- a/training/l200-tools/lab2-ai-search/data/health-plan.md
+++ b/training/l200-tools/lab2-ai-search/data/health-plan.md
@@ -1,0 +1,12 @@
+# Health Plan
+
+Contoso offers two medical plans: the **Standard PPO** and the **High-Deductible Health Plan
+(HDHP)** with a health savings account (HSA).
+
+- Standard PPO: $500 individual deductible, $1,000 family deductible. Contoso pays 80% of the
+  monthly premium.
+- HDHP: $1,600 individual deductible, $3,200 family deductible. Contoso contributes $1,000 per year
+  to the employee's HSA.
+
+Open enrollment runs for two weeks each November. Coverage for new hires begins on the first day of
+the month following their start date.

--- a/training/l200-tools/lab2-ai-search/data/parental-leave.md
+++ b/training/l200-tools/lab2-ai-search/data/parental-leave.md
@@ -1,0 +1,10 @@
+# Parental Leave Policy
+
+Contoso provides **12 weeks** of paid parental leave to all new parents, including birth, adoption,
+and foster placement. Leave must be taken within the first 12 months following the birth or
+placement of the child.
+
+Parental leave is paid at 100% of base salary. It may be taken continuously or, with manager
+approval, split into two blocks of at least four weeks each.
+
+Employees become eligible for parental leave after **90 days** of employment.

--- a/training/l200-tools/lab2-ai-search/data/pto-policy.md
+++ b/training/l200-tools/lab2-ai-search/data/pto-policy.md
@@ -1,0 +1,11 @@
+# Paid Time Off (PTO) Policy
+
+New full-time employees at Contoso accrue **15 days** of paid time off per year during their first
+two years. Starting in year three, accrual increases to 20 days per year, and to 25 days per year
+after five years of service.
+
+PTO begins accruing on the employee's start date. Unused PTO of up to 5 days may be carried over
+into the next calendar year; any balance above 5 days is forfeited on December 31.
+
+PTO requests must be submitted at least two weeks in advance for absences longer than three
+consecutive days.

--- a/training/l200-tools/lab2-ai-search/data/remote-work-policy.md
+++ b/training/l200-tools/lab2-ai-search/data/remote-work-policy.md
@@ -1,0 +1,12 @@
+# Remote Work Policy
+
+Contoso supports a **hybrid work model**. Most employees are expected to work from a Contoso office
+at least **two days per week**. Teams may set additional in-office expectations with manager
+approval.
+
+Fully remote arrangements require director-level approval and are reviewed annually. Employees
+working remotely must maintain a secure internet connection and use the company VPN when accessing
+internal systems.
+
+Contoso provides a one-time **$500 home office stipend** to employees approved for hybrid or remote
+work.

--- a/training/l200-tools/lab2-ai-search/data/retirement-401k.md
+++ b/training/l200-tools/lab2-ai-search/data/retirement-401k.md
@@ -1,0 +1,10 @@
+# 401(k) Retirement Plan
+
+Contoso matches employee 401(k) contributions **dollar-for-dollar up to 4%** of eligible
+compensation. The match vests over three years: 33% after year one, 66% after year two, and 100%
+after year three.
+
+Employees may enroll or change contributions at any time through the Contoso Benefits portal.
+Automatic enrollment at 3% begins 60 days after the start date unless the employee opts out.
+
+The 2026 IRS contribution limit for employee deferrals is **$24,000**.

--- a/training/l200-tools/lab3-foundry-iq/00_reset.py
+++ b/training/l200-tools/lab3-foundry-iq/00_reset.py
@@ -1,0 +1,43 @@
+"""Reset Lab 3 by deleting its agents, connection, knowledge base, and knowledge source.
+
+Leaves the Lab 2 `contoso-benefits` index in place (this lab reuses it). Order matters: the KB
+references the knowledge source, so delete the KB before the source.
+"""
+
+import common
+import requests
+
+
+def main():
+    for name in common.AGENT_NAMES:
+        try:
+            common.project.agents.delete(name)
+            print(f"deleted agent {name}")
+        except Exception as exc:
+            print(f"agent {name} not deleted ({str(exc)[:80]})")
+
+    try:
+        resp = requests.delete(
+            f"https://management.azure.com{common.PROJECT_RESOURCE_ID}/connections/"
+            f"{common.KB_CONNECTION_NAME}?api-version=2025-10-01-preview",
+            headers={"Authorization": f"Bearer {common._arm_token()}"},
+        )
+        print(f"deleted connection {common.KB_CONNECTION_NAME} (status {resp.status_code})")
+    except Exception as exc:
+        print(f"connection not deleted ({str(exc)[:80]})")
+
+    ic = common.index_client()
+    try:
+        ic.delete_knowledge_base(common.KB_NAME)
+        print(f"deleted knowledge base {common.KB_NAME}")
+    except Exception as exc:
+        print(f"knowledge base not deleted ({str(exc)[:80]})")
+    try:
+        ic.delete_knowledge_source(common.KS_NAME)
+        print(f"deleted knowledge source {common.KS_NAME}")
+    except Exception as exc:
+        print(f"knowledge source not deleted ({str(exc)[:80]})")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab3-foundry-iq/01_create_kb.py
+++ b/training/l200-tools/lab3-foundry-iq/01_create_kb.py
@@ -1,0 +1,31 @@
+"""Create the Foundry IQ knowledge base and project connection.
+
+Creates:
+- a knowledge source over the Lab 2 `contoso-benefits` index,
+- the knowledge base (with the configured model for query planning + answer synthesis),
+- the RemoteTool project connection that targets the KB's MCP endpoint.
+
+Prerequisite: run Lab 2 first so the `contoso-benefits` index exists. See README for required roles.
+"""
+
+import common
+
+
+def main():
+    common.create_knowledge_source()
+    print(f"knowledge source: {common.KS_NAME} (over index {common.INDEX_NAME})")
+
+    common.create_knowledge_base()
+    print(
+        f"knowledge base:   {common.KB_NAME} "
+        f"(model={common.MODEL_DEPLOYMENT_NAME}, answerSynthesis, effort=medium)"
+    )
+
+    common.create_kb_connection()
+    print(f"project connection: {common.KB_CONNECTION_NAME} -> {common.mcp_endpoint()}")
+
+    print("\nBuilt. Next: python 02_query.py")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab3-foundry-iq/02_query.py
+++ b/training/l200-tools/lab3-foundry-iq/02_query.py
@@ -1,0 +1,59 @@
+"""Connect two agents to the same knowledge base and verify shared, cited answers.
+
+Builds two agents (hr-assistant, onboarding-assistant), each consuming the KB via the MCP tool.
+Asks a multi-part question that forces the KB to decompose the query, and confirms both agents
+return cited answers from the shared KB. A final off-topic question confirms grounding discipline.
+
+See the README for the managed-identity role requirements.
+"""
+
+import common
+
+MULTI_PART = "What is Contoso's 401k match, and how many PTO days do new employees get?"
+OFF_TOPIC = "What is the capital of France?"
+
+
+def _contains_both_policy_facts(answer: str) -> bool:
+    text = answer.lower()
+    has_match = any(value in text for value in ("4%", "4 percent", "four percent"))
+    has_pto = any(value in text for value in ("15 days", "15-day", "fifteen days"))
+    return has_match and has_pto
+
+
+def main():
+    agents = [common.build_agent(name) for name in common.AGENT_NAMES]
+    print("agents on the shared KB: " + ", ".join(f"{a.name} v{a.version}" for a in agents) + "\n")
+
+    for agent in agents:
+        print(f"===== {agent.name} =====")
+        answer, tool_used, annotations = common.run_agent(agent, MULTI_PART)
+        print(f"Q (multi-part): {MULTI_PART}")
+        print(f"   tool_used={tool_used} citations={annotations}")
+        print(f"   A: {answer}\n")
+        assert tool_used, "expected the knowledge base MCP tool to be called"
+        assert annotations > 0, "expected at least one citation"
+        assert _contains_both_policy_facts(answer), (
+            "expected the answer to include the 4% 401k match and 15 PTO days"
+        )
+
+    # Negative case: not in the KB -> the agent should decline, not answer from memory.
+    for agent in agents:
+        answer, tool_used, annotations = common.run_agent(agent, OFF_TOPIC)
+        print(f"Q (off-topic, {agent.name}): {OFF_TOPIC}")
+        print(f"   tool_used={tool_used} citations={annotations}")
+        print(f"   A: {answer}\n")
+        declined = "don't know" in answer.lower() or "do not know" in answer.lower()
+        assert tool_used, "expected the knowledge base MCP tool to be called"
+        assert declined, f"expected a decline for the off-topic question, got: {answer!r}"
+        assert "paris" not in answer.lower(), (
+            f"agent answered from memory instead of declining: {answer!r}"
+        )
+
+    print(
+        "PASS: both agents share one KB, answer a multi-part question with citations,\n"
+        "      and decline an off-topic question."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/training/l200-tools/lab3-foundry-iq/README.md
+++ b/training/l200-tools/lab3-foundry-iq/README.md
@@ -1,0 +1,79 @@
+# Lab 3: Foundry IQ knowledge base
+
+This lab reuses the Lab 2 index as a Foundry IQ knowledge source. It creates one model-backed
+knowledge base and connects two agents through the same MCP project connection.
+
+Follow the L200 module for the teaching steps and screenshots. This README is the operational
+companion for running the code.
+
+## Before you begin
+
+1. Complete Lab 2 and keep the `contoso-benefits` index.
+2. Complete the [shared workstation setup](../README.md).
+3. Activate `training/l200-tools/.venv`.
+4. Fill in these values in `training/l200-tools/.env`:
+   - `PROJECT_ENDPOINT`
+   - `MODEL_DEPLOYMENT_NAME`
+   - `SEARCH_CONNECTION_NAME`
+   - `PROJECT_RESOURCE_ID`
+   - `AOAI_ENDPOINT`
+   - `MODEL_NAME` only when it differs from the deployment name
+5. Choose a model supported by Foundry IQ for query planning and answer synthesis. The agent model
+   must also support MCP.
+6. From `training/l200-tools`, run:
+
+   ```bash
+   python check_setup.py --lab 3
+   cd lab3-foundry-iq
+   ```
+
+## Required roles
+
+| Identity | Role and scope |
+|---|---|
+| Foundry project managed identity | `Search Index Data Reader` on the Search service. The Lab 2 data-contributor grant also provides read access. |
+| Search service managed identity | `Cognitive Services User` on the Foundry model resource. |
+| Your user account | `Search Service Contributor` on Search, plus `Foundry User` and `Foundry Project Manager` on the Foundry resource. |
+
+If either managed identity is missing its role, the knowledge resources can look correct while
+runtime retrieval fails.
+
+## Run order
+
+| Script | Purpose |
+|---|---|
+| `00_reset.py` | Delete the two agents, project connection, knowledge base, and knowledge source. |
+| `01_create_kb.py` | Create the knowledge source, model-backed knowledge base, and RemoteTool connection. |
+| `02_query.py` | Connect two agents and verify cited multi-part answers and off-topic declines. |
+
+Run each command separately:
+
+```bash
+python 00_reset.py
+python 01_create_kb.py
+python 02_query.py
+```
+
+The lab succeeds when `02_query.py` prints:
+
+```text
+PASS: both agents share one KB, answer a multi-part question with citations,
+      and decline an off-topic question.
+```
+
+## Cleanup
+
+```bash
+python 00_reset.py
+```
+
+The Lab 2 Search index is intentionally preserved.
+
+## Common execution problems
+
+| Symptom | Check |
+|---|---|
+| `tool_user_error: Access denied` | Verify both sides of the managed-identity chain and allow time for role propagation. |
+| `A Knowledge Base model must be specified...` | Verify `MODEL_DEPLOYMENT_NAME`, `MODEL_NAME`, and `AOAI_ENDPOINT`. |
+| Agent cannot connect to the MCP endpoint | Verify the project connection target, audience, and `ProjectManagedIdentity` authentication. |
+| Answer has no citations | Confirm `knowledge_base_retrieve` was called and the model supports MCP. |

--- a/training/l200-tools/lab3-foundry-iq/common.py
+++ b/training/l200-tools/lab3-foundry-iq/common.py
@@ -1,0 +1,208 @@
+"""Shared helpers for Lab 3 (Foundry IQ knowledge base).
+
+Every script imports from here so the setup lives in one place.
+
+What this lab builds:
+- A reusable Foundry IQ *knowledge base* (KB) in Azure AI Search: a knowledge source over the Lab 2
+  `contoso-benefits` index, plus an LLM for query planning and answer synthesis.
+- The KB exposes an MCP endpoint. A Foundry project *connection* (RemoteTool + project managed
+  identity) targets that endpoint, and each agent adds it as an MCP tool. One KB -> many agents.
+
+API versions (deliberate mix):
+- The search *index* and the *knowledge source* are generally available (2026-04-01) and created with
+  the stable `azure-search-documents` SDK.
+- A KB *with a model* (answer synthesis, configurable reasoning effort) is a 2026-05-01-preview
+  feature the stable SDK will not send, so the KB is created via a raw REST PUT at that api-version.
+- The agent<->KB connection uses the MCP endpoint at 2026-05-01-preview.
+"""
+
+import os
+from pathlib import Path
+from typing import Optional
+
+import requests
+from azure.ai.projects import AIProjectClient
+from azure.ai.projects.models import MCPTool, PromptAgentDefinition
+from azure.identity import DefaultAzureCredential
+from azure.search.documents.indexes import SearchIndexClient
+from azure.search.documents.indexes.models import (
+    SearchIndexFieldReference,
+    SearchIndexKnowledgeSource,
+    SearchIndexKnowledgeSourceParameters,
+)
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[1] / ".env")
+
+MODEL_DEPLOYMENT_NAME = os.environ.get("MODEL_DEPLOYMENT_NAME")
+MODEL_NAME = os.environ.get("MODEL_NAME") or MODEL_DEPLOYMENT_NAME
+INDEX_NAME = "contoso-benefits"  # reused from Lab 2
+SEMANTIC_CONFIG = "default"
+KS_NAME = "contoso-benefits-ks"
+KB_NAME = "contoso-benefits-kb"
+KB_CONNECTION_NAME = "contoso-kb-mcp"
+AGENT_NAMES = ["hr-assistant", "onboarding-assistant"]
+
+SEARCH_CONNECTION_NAME = os.environ.get("SEARCH_CONNECTION_NAME")
+KB_API_VERSION = "2026-05-01-preview"
+
+PROJECT_ENDPOINT = os.environ.get("PROJECT_ENDPOINT")
+PROJECT_RESOURCE_ID = os.environ.get("PROJECT_RESOURCE_ID")
+# The Azure OpenAI endpoint on the Foundry resource that hosts the KB's query-planning model.
+AOAI_ENDPOINT = os.environ.get("AOAI_ENDPOINT")
+
+
+def _required(value: Optional[str], variable: str) -> str:
+    if not value:
+        raise RuntimeError(f"Set {variable} in training/l200-tools/.env.")
+    return value
+
+
+_credential = DefaultAzureCredential()
+project = AIProjectClient(
+    endpoint=_required(PROJECT_ENDPOINT, "PROJECT_ENDPOINT"),
+    credential=_credential,
+)
+
+_conn = project.connections.get(_required(SEARCH_CONNECTION_NAME, "SEARCH_CONNECTION_NAME"))
+SEARCH_ENDPOINT = _conn.target.rstrip("/")
+
+
+def index_client() -> SearchIndexClient:
+    return SearchIndexClient(endpoint=SEARCH_ENDPOINT, credential=_credential)
+
+
+def mcp_endpoint() -> str:
+    """The KB's MCP endpoint, which the agent calls to run agentic retrieval."""
+    return f"{SEARCH_ENDPOINT}/knowledgebases/{KB_NAME}/mcp?api-version={KB_API_VERSION}"
+
+
+def _search_token() -> str:
+    return _credential.get_token("https://search.azure.com/.default").token
+
+
+def _arm_token() -> str:
+    return _credential.get_token("https://management.azure.com/.default").token
+
+
+def create_knowledge_source() -> None:
+    """Create a search-index knowledge source over the Lab 2 index (GA SDK)."""
+    ks = SearchIndexKnowledgeSource(
+        name=KS_NAME,
+        description="Contoso employee benefits, sourced from the Lab 2 search index.",
+        search_index_parameters=SearchIndexKnowledgeSourceParameters(
+            search_index_name=INDEX_NAME,
+            semantic_configuration_name=SEMANTIC_CONFIG,
+            source_data_fields=[
+                SearchIndexFieldReference(name=f) for f in ("id", "title", "content", "category")
+            ],
+            search_fields=[SearchIndexFieldReference(name=f) for f in ("title", "content")],
+        ),
+    )
+    index_client().create_or_update_knowledge_source(ks)
+
+
+def create_knowledge_base() -> None:
+    """Create the KB with an LLM (answer synthesis + reasoning effort) via preview REST."""
+    model_deployment = _required(MODEL_DEPLOYMENT_NAME, "MODEL_DEPLOYMENT_NAME")
+    model_name = _required(MODEL_NAME, "MODEL_NAME")
+    model_endpoint = _required(AOAI_ENDPOINT, "AOAI_ENDPOINT")
+    body = {
+        "name": KB_NAME,
+        "description": "Reusable benefits knowledge base shared across agents.",
+        "knowledgeSources": [{"name": KS_NAME}],
+        "models": [
+            {
+                "kind": "azureOpenAI",
+                "azureOpenAIParameters": {
+                    "resourceUri": model_endpoint,
+                    "deploymentId": model_deployment,
+                    "modelName": model_name,
+                },
+            }
+        ],
+        "outputMode": "answerSynthesis",
+        "retrievalReasoningEffort": {"kind": "medium"},
+    }
+    resp = requests.put(
+        f"{SEARCH_ENDPOINT}/knowledgebases/{KB_NAME}?api-version={KB_API_VERSION}",
+        headers={"Authorization": f"Bearer {_search_token()}", "Content-Type": "application/json"},
+        json=body,
+    )
+    resp.raise_for_status()
+
+
+def create_kb_connection() -> None:
+    """Create the RemoteTool project connection that targets the KB's MCP endpoint.
+
+    authType=ProjectManagedIdentity: the agent reaches the KB as the project MI, which needs
+    Search Index Data Reader on the search service (granted in Lab 2).
+    """
+    body = {
+        "name": KB_CONNECTION_NAME,
+        "type": "Microsoft.MachineLearningServices/workspaces/connections",
+        "properties": {
+            "authType": "ProjectManagedIdentity",
+            "category": "RemoteTool",
+            "target": mcp_endpoint(),
+            "isSharedToAll": True,
+            "audience": "https://search.azure.com/",
+            "metadata": {"ApiType": "Azure"},
+        },
+    }
+    resp = requests.put(
+        f"https://management.azure.com{_required(PROJECT_RESOURCE_ID, 'PROJECT_RESOURCE_ID')}"
+        f"/connections/{KB_CONNECTION_NAME}"
+        "?api-version=2025-10-01-preview",
+        headers={"Authorization": f"Bearer {_arm_token()}", "Content-Type": "application/json"},
+        json=body,
+    )
+    resp.raise_for_status()
+
+
+_INSTRUCTIONS = (
+    "You are a helpful assistant that must use the knowledge base tool to answer every question. "
+    "Never answer from your own knowledge. Include citations to the retrieved sources. "
+    'If the knowledge base does not contain the answer, respond with "I don\'t know".'
+)
+
+
+def build_agent(agent_name: str):
+    """Create an agent version that consumes the KB as an MCP tool."""
+    model_deployment = _required(MODEL_DEPLOYMENT_NAME, "MODEL_DEPLOYMENT_NAME")
+    tool = MCPTool(
+        server_label="knowledge-base",
+        server_url=mcp_endpoint(),
+        require_approval="never",
+        allowed_tools=["knowledge_base_retrieve"],
+        project_connection_id=KB_CONNECTION_NAME,
+    )
+    return project.agents.create_version(
+        agent_name=agent_name,
+        definition=PromptAgentDefinition(
+            model=model_deployment,
+            instructions=_INSTRUCTIONS,
+            tools=[tool],
+        ),
+    )
+
+
+def run_agent(agent, question: str):
+    """One turn against a KB-backed agent. Returns (answer, tool_used, annotation_count)."""
+    oc = project.get_openai_client()
+    response = oc.responses.create(
+        input=question,
+        extra_body={
+            "agent_reference": {"type": "agent_reference", "name": agent.name, "version": agent.version}
+        },
+    )
+    tool_used = False
+    annotations = 0
+    for item in response.output:
+        item_type = getattr(item, "type", None)
+        if item_type == "mcp_call" and getattr(item, "name", "") == "knowledge_base_retrieve":
+            tool_used = True
+        if item_type == "message":
+            for block in getattr(item, "content", []) or []:
+                annotations += len(getattr(block, "annotations", []) or [])
+    return (response.output_text or ""), tool_used, annotations

--- a/training/l200-tools/requirements.txt
+++ b/training/l200-tools/requirements.txt
@@ -1,0 +1,5 @@
+azure-ai-projects==2.3.0
+azure-identity==1.25.3
+azure-search-documents==12.0.0
+python-dotenv==1.2.2
+requests==2.34.2


### PR DESCRIPTION
Summary: adds a connected three-lab L200 tools suite under training/l200-tools, Windows-first workstation setup, a shared pinned environment and preflight checker, plus the approved training-suite architecture exception. Validation: all 167 existing tests pass; all training scripts compile; setup checks were validated for missing and complete configuration.